### PR TITLE
Reference remote Firewall in Hub

### DIFF
--- a/modules/compute/aks/aks.tf
+++ b/modules/compute/aks/aks.tf
@@ -76,6 +76,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
       node_labels           = try(var.settings.default_node_pool.node_labels, null)
       node_taints           = try(var.settings.default_node_pool.node_taints, null)
       vnet_subnet_id        = var.subnets[var.settings.default_node_pool.subnet_key].id
+      orchestrator_version  = try(var.settings.default_node_pool.orchestrator_version, var.settings.kubernetes_version)
       tags                  = merge(try(var.settings.default_node_pool.tags, {}), local.tags)
     }
 

--- a/modules/compute/aks/output.tf
+++ b/modules/compute/aks/output.tf
@@ -47,3 +47,11 @@ output kube_config {
 output rbac_id {
   value = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id
 }
+
+output node_resource_group {
+  value = azurerm_kubernetes_cluster.aks.node_resource_group
+}
+
+output private_fqdn {
+  value = azurerm_kubernetes_cluster.aks.private_fqdn
+}


### PR DESCRIPTION
Added private_fdqn & node_rg to AKS output.
Support orchestrator_version for Default nodepool
Add remote tfstate in networking module to allow spoke to reference Firewall in hub LZ

azurerm_routes = {

  default_to_firewall_rg1 = {
    name               = "0-0-0-0-through-firewall-rg1"
    resource_group_key = "aks_spoke_rg1"
    route_table_key    = "default_to_firewall_rg1"
    address_prefix     = "0.0.0.0/0"
    next_hop_type      = "VirtualAppliance"
    remote_tfstate = {
      tfstate_key = "networking_hub"
      output_key  = "azurerm_firewalls"
      fw_key      = "fw_rg1"
      interface_index = 0
    }
}